### PR TITLE
fix: ResizeObserver loop completed with undelivered notifications

### DIFF
--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import {
   CheckIcon,

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 

--- a/src/entries/contentScript/primary/components/Controlbar.tsx
+++ b/src/entries/contentScript/primary/components/Controlbar.tsx
@@ -134,10 +134,12 @@ export default function Controlbar({ appRoot, onClose }: ControlbarProps) {
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(() => {
-      const container = containerRef.current
-      if (container) {
-        setContainerBoundingRect(container.getBoundingClientRect())
-      }
+      requestAnimationFrame(() => {
+        const container = containerRef.current
+        if (container) {
+          setContainerBoundingRect(container.getBoundingClientRect())
+        }
+      })
     })
 
     const container = containerRef.current


### PR DESCRIPTION
## Summary
- Fixed "ResizeObserver loop completed with undelivered notifications" error by wrapping the `ResizeObserver` callback in `requestAnimationFrame`, breaking the synchronous resize → state update → re-render cycle
- Removed unused `eslint-disable react/prop-types` directives that were failing the pre-push hook

## Test plan
- [ ] Verify Controlbar drag bounds still update correctly on resize
- [ ] Confirm no ResizeObserver loop errors in Chrome console

🤖 Generated with [Claude Code](https://claude.com/claude-code)