### PR TITLE
fix: guard chrome.scripting.executeScript against non-scriptable URLs

### DIFF
--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -33,7 +33,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (
     changeInfo.status === 'loading' &&
     enabledTabs.has(tabId) &&
-    isScriptableUrl(tab.url)
+    isScriptableUrl(tab.pendingUrl ?? tab.url)
   ) {
     chrome.scripting.executeScript({
       target: { tabId },
@@ -49,11 +49,12 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 })
 
 chrome.action.onClicked.addListener(async (tab) => {
-  if (!tab.id || !isScriptableUrl(tab.url)) return
+  if (!tab.id) return
 
   if (isRecording) {
     stopRecording()
   } else {
+    if (!isScriptableUrl(tab.url)) return
     if (enabledTabs.has(tab.id)) {
       sendTabMessage(tab.id, { type: 'show-controlbar' })
     } else {

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser'
 import { offscreenUrl } from '~/constants'
-import { getCurrentTab, getStreamId, hasOffscreenDocument } from '~/lib/utils'
+import { getCurrentTab, getStreamId, hasOffscreenDocument, isScriptableUrl } from '~/lib/utils'
 import { RecordingMode, RecordingOptions } from '~/types'
 import { useStore } from '../store'
 
@@ -29,8 +29,12 @@ function stopRecording() {
   }
 }
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, _tab) => {
-  if (changeInfo.status === 'loading' && enabledTabs.has(tabId)) {
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (
+    changeInfo.status === 'loading' &&
+    enabledTabs.has(tabId) &&
+    isScriptableUrl(tab.url)
+  ) {
     chrome.scripting.executeScript({
       target: { tabId },
       files: ['/src/entries/contentScript/primary/main.js'],
@@ -45,7 +49,7 @@ chrome.tabs.onRemoved.addListener((tabId) => {
 })
 
 chrome.action.onClicked.addListener(async (tab) => {
-  if (!tab.id) return
+  if (!tab.id || !isScriptableUrl(tab.url)) return
 
   if (isRecording) {
     stopRecording()

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,6 +49,18 @@ export function getStreamId(tabId: number) {
   })
 }
 
+export function isScriptableUrl(url?: string) {
+  if (!url) return false
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false
+    if (parsed.hostname === 'chromewebstore.google.com') return false
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function isWindows() {
   return navigator.userAgent.includes('Windows')
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,7 +53,7 @@ export function isScriptableUrl(url?: string) {
   if (!url) return false
   try {
     const parsed = new URL(url)
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:' && parsed.protocol !== 'file:') return false
     if (parsed.hostname === 'chromewebstore.google.com') return false
     return true
   } catch {


### PR DESCRIPTION
## Summary
- Guards `chrome.scripting.executeScript` calls against non-scriptable URLs (chrome:// pages, Chrome Web Store, other extension pages)
- Adds `isScriptableUrl()` utility that validates URLs before script injection
- Prevents "The extensions gallery cannot be scripted" error from being thrown in the service worker

## Test plan
- [ ] Click extension icon on a normal http/https page — recording control bar should appear
- [ ] Click extension icon on `chrome://extensions/` — should silently no-op (no error in service worker console)
- [ ] Navigate to `https://chromewebstore.google.com/` with extension enabled — should not attempt script injection
- [ ] Normal tab recording flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)