### PR TITLE
fix: reset recording state when desktop capture is cancelled

### DIFF
--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -17,6 +17,9 @@ let resultTabId: number | null = null
 const enabledTabs = new Set()
 
 function resetRecordingState() {
+  if (recordingTabId) {
+    sendTabMessage(recordingTabId, { type: 'stop-recording' })
+  }
   chrome.action.setBadgeText({ text: '' })
   useStore.setState({ isRecording: false })
   isRecording = false
@@ -60,6 +63,9 @@ chrome.tabs.onRemoved.addListener((tabId) => {
     if (isRecording) {
       resetRecordingState()
     }
+  }
+  if (tabId === recordingTabId && isRecording) {
+    resetRecordingState()
   }
 })
 

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -16,6 +16,19 @@ let recordingTabId: number | null = null
 let resultTabId: number | null = null
 const enabledTabs = new Set()
 
+function resetRecordingState() {
+  chrome.action.setBadgeText({ text: '' })
+  useStore.setState({ isRecording: false })
+  isRecording = false
+  recordingTabId = null
+  recordingMode = null
+  if (resultTabId) {
+    chrome.tabs.remove(resultTabId).catch(() => {})
+    resultTabId = null
+  }
+  chrome.offscreen.closeDocument().catch(() => {})
+}
+
 function stopRecording() {
   sendMessage({
     type: 'stop-recording',
@@ -41,6 +54,12 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, _tab) => {
 chrome.tabs.onRemoved.addListener((tabId) => {
   if (enabledTabs.has(tabId)) {
     enabledTabs.delete(tabId)
+  }
+  if (tabId === resultTabId) {
+    resultTabId = null
+    if (isRecording) {
+      resetRecordingState()
+    }
   }
 })
 
@@ -120,6 +139,10 @@ chrome.runtime.onMessage.addListener(
         isRecording = false
         recordingTabId = null
         recordingMode = null
+        resultTabId = null
+        break
+      case 'recording-cancelled':
+        resetRecordingState()
         break
       case 'start-recording':
         startRecording(message.data)

--- a/src/entries/tabs/App.tsx
+++ b/src/entries/tabs/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import Confetti from 'react-confetti'
 import Recorder from '~/lib/recording'
+import { sendMessage } from '~/lib/utils'
 import { RecordingOptions } from '~/types'
 
 const params = new URLSearchParams(location.search)
@@ -23,6 +24,14 @@ export default function App() {
     const desktopMediaRequestId = chrome.desktopCapture.chooseDesktopMedia(
       ['screen', 'window', 'audio'],
       (streamId, { canRequestAudioTrack }) => {
+        if (!streamId) {
+          sendMessage({
+            type: 'recording-cancelled',
+            target: 'background',
+          })
+          window.close()
+          return
+        }
         recorder.start(
           {
             streamId,

--- a/src/lib/recording.ts
+++ b/src/lib/recording.ts
@@ -112,9 +112,18 @@ class Recorder {
       video: videoConstraints,
     }
 
-    this.media = await navigator.mediaDevices.getUserMedia(
-      mediaStreamConstraints
-    )
+    try {
+      this.media = await navigator.mediaDevices.getUserMedia(
+        mediaStreamConstraints
+      )
+    } catch (err) {
+      console.error('Failed to get media stream:', err)
+      sendMessage({
+        type: 'recording-cancelled',
+        target: 'background',
+      })
+      return
+    }
 
     if (audio) {
       const audioContext = new AudioContext()


### PR DESCRIPTION
## Summary
- When the user cancels the desktop capture dialog, the extension badge stayed stuck in "REC" state with no way to recover
- Added `resetRecordingState()` helper in background to cleanly reset badge, store, result tab, and offscreen document
- Fixed `tabs/App.tsx` to check for valid `streamId` before starting the recorder — sends `recording-cancelled` and closes the tab on cancel
- Fixed `lib/recording.ts` to catch `getUserMedia()` failures and notify the background instead of silently failing
- Fixed `chrome.tabs.onRemoved` to detect when the user closes the desktop picker tab mid-recording and reset state

## Test plan
- [ ] Start desktop recording → click Cancel in the screen picker dialog → badge should clear, extension should return to idle
- [ ] Close the desktop picker tab while REC badge is shown → badge should clear
- [ ] Normal desktop recording flow still works end-to-end
- [ ] Tab/area recording still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)