### PR TITLE
限制开发环境 Sentry 并规范生产 sourcemap 上传

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Optional. Enables Sentry sourcemap upload during production builds.
+# Keep real tokens out of git. Set this in CI secrets or local ignored env files.
+SENTRY_AUTH_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 **/node_modules
 .DS_Store
 storybook-static
+.env*
+!.env.example
 # Sentry Auth Token
 .env.sentry-build-plugin
 .claude/

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/browser'
 import { offscreenUrl } from '~/constants'
 import {
   getCurrentTab,
@@ -11,10 +10,12 @@ import {
 import { RecordingMode, RecordingOptions } from '~/types'
 import { useStore } from '../store'
 
-if (process.env.NODE_ENV === 'production') {
-  Sentry.init({
-    dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-  })
+if (import.meta.env.MODE === 'production') {
+  void import('@sentry/browser').then(({ init }) =>
+    init({
+      dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
+    }),
+  )
 }
 
 let isRecording = false

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -17,7 +17,9 @@ if (import.meta.env.MODE === 'production') {
         dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
       }),
     )
-    .catch(() => {})
+    .catch((error) => {
+      console.error('Failed to initialize Sentry in background.', error)
+    })
 }
 
 let isRecording = false

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -11,11 +11,13 @@ import { RecordingMode, RecordingOptions } from '~/types'
 import { useStore } from '../store'
 
 if (import.meta.env.MODE === 'production') {
-  void import('@sentry/browser').then(({ init }) =>
-    init({
-      dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-    }),
-  )
+  void import('@sentry/browser')
+    .then(({ init }) =>
+      init({
+        dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
+      }),
+    )
+    .catch(() => {})
 }
 
 let isRecording = false

--- a/src/entries/contentScript/primary/main.tsx
+++ b/src/entries/contentScript/primary/main.tsx
@@ -13,7 +13,9 @@ if (import.meta.env.MODE === 'production') {
         dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
       }),
     )
-    .catch(() => {})
+    .catch((error) => {
+      console.error('Failed to initialize Sentry in content script.', error)
+    })
 }
 
 chrome.runtime.onMessage.addListener((message, _sener, _sendResponse) => {

--- a/src/entries/contentScript/primary/main.tsx
+++ b/src/entries/contentScript/primary/main.tsx
@@ -4,13 +4,14 @@ import ReactDOM from 'react-dom/client'
 import renderContent from '../renderContent'
 import App from './App'
 import '~/style.css'
-import * as Sentry from '@sentry/react'
 import { useStore } from '~/entries/store'
 
-if (process.env.NODE_ENV === 'production') {
-  Sentry.init({
-    dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-  })
+if (import.meta.env.MODE === 'production') {
+  void import('@sentry/react').then(({ init }) =>
+    init({
+      dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
+    }),
+  )
 }
 
 chrome.runtime.onMessage.addListener((message, _sener, _sendResponse) => {

--- a/src/entries/contentScript/primary/main.tsx
+++ b/src/entries/contentScript/primary/main.tsx
@@ -7,11 +7,13 @@ import '~/style.css'
 import { useStore } from '~/entries/store'
 
 if (import.meta.env.MODE === 'production') {
-  void import('@sentry/react').then(({ init }) =>
-    init({
-      dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-    }),
-  )
+  void import('@sentry/react')
+    .then(({ init }) =>
+      init({
+        dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
+      }),
+    )
+    .catch(() => {})
 }
 
 chrome.runtime.onMessage.addListener((message, _sener, _sendResponse) => {

--- a/src/entries/tabs/main.tsx
+++ b/src/entries/tabs/main.tsx
@@ -3,12 +3,13 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import '../../style.css'
-import * as Sentry from '@sentry/react'
 
-if (process.env.NODE_ENV === 'production') {
-  Sentry.init({
-    dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-  })
+if (import.meta.env.MODE === 'production') {
+  void import('@sentry/react').then(({ init }) =>
+    init({
+      dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
+    }),
+  )
 }
 
 ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(

--- a/src/entries/tabs/main.tsx
+++ b/src/entries/tabs/main.tsx
@@ -11,7 +11,9 @@ if (import.meta.env.MODE === 'production') {
         dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
       }),
     )
-    .catch(() => {})
+    .catch((error) => {
+      console.error('Failed to initialize Sentry in tabs page.', error)
+    })
 }
 
 ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(

--- a/src/entries/tabs/main.tsx
+++ b/src/entries/tabs/main.tsx
@@ -5,11 +5,13 @@ import App from './App'
 import '../../style.css'
 
 if (import.meta.env.MODE === 'production') {
-  void import('@sentry/react').then(({ init }) =>
-    init({
-      dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-    }),
-  )
+  void import('@sentry/react')
+    .then(({ init }) =>
+      init({
+        dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
+      }),
+    )
+    .catch(() => {})
 }
 
 ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig(({ mode }) => {
       port: 4173,
     },
     build: {
-      sourcemap: enableSentryUpload,
+      sourcemap: enableSentryUpload ? 'hidden' : false,
     },
   }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,10 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import { getManifest } from './src/manifest'
 
-export default defineConfig(() => {
+export default defineConfig(({ mode }) => {
+  const isProduction = mode === 'production'
+  const enableSentryUpload = isProduction && !!process.env.SENTRY_AUTH_TOKEN
+
   return {
     plugins: [
       react(),
@@ -22,11 +25,16 @@ export default defineConfig(() => {
             },
           })
         : undefined,
-      sentryVitePlugin({
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        org: 'maltoze',
-        project: 'sgreen',
-      }),
+      enableSentryUpload
+        ? sentryVitePlugin({
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            org: 'maltoze',
+            project: 'sgreen',
+            sourcemaps: {
+              filesToDeleteAfterUpload: ['dist/**/*.map'],
+            },
+          })
+        : undefined,
     ],
     resolve: {
       alias: {
@@ -37,7 +45,7 @@ export default defineConfig(() => {
       port: 4173,
     },
     build: {
-      sourcemap: true,
+      sourcemap: enableSentryUpload,
     },
   }
 })


### PR DESCRIPTION
**Summary**
- 开发模式下不再启用 Sentry，也不再为本地构建生成 sourcemap。
- 生产模式仅在存在 `SENTRY_AUTH_TOKEN` 时启用 Sentry 上传，并在上传后删除 `dist/**/*.map`。
- 新增 `.env.example`，补充 `SENTRY_AUTH_TOKEN` 的使用说明，并更新 `.gitignore` 忽略本地环境文件。

**Testing**
- `pnpm tsc`
- `pnpm lint`
- 本地 `pnpm build` 在未设置 `SENTRY_AUTH_TOKEN` 时通过，且 `dist` 中未生成 `.map` 文件