### PR TITLE
Fix Sentry background type error and keep lint formatting clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ storybook-static
 # Sentry Auth Token
 .env.sentry-build-plugin
 .claude/
+.env

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -10,13 +10,16 @@ import {
 import { RecordingMode, RecordingOptions } from '~/types'
 import { useStore } from '../store'
 
+let captureException: (err: unknown) => void = () => {}
+
 if (import.meta.env.MODE === 'production') {
   void import('@sentry/browser')
-    .then(({ init }) =>
-      init({
+    .then((Sentry) => {
+      captureException = Sentry.captureException
+      Sentry.init({
         dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-      }),
-    )
+      })
+    })
     .catch((error) => {
       console.error('Failed to initialize Sentry in background.', error)
     })
@@ -128,7 +131,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     isScriptableUrl(tab.pendingUrl ?? tab.url)
   ) {
     void executeContentScript(tabId).catch((err) =>
-      Sentry.captureException(err),
+      captureException(err),
     )
   }
 })

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -130,9 +130,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     enabledTabs.has(tabId) &&
     isScriptableUrl(tab.pendingUrl ?? tab.url)
   ) {
-    void executeContentScript(tabId).catch((err) =>
-      captureException(err),
-    )
+    void executeContentScript(tabId).catch((err) => captureException(err))
   }
 })
 


### PR DESCRIPTION
## Summary
- Replace the undefined `Sentry` reference in the background entry with a locally stored `captureException` handler
- Initialize Sentry through the dynamically imported module object in production
- Ignore local environment files in `.gitignore`

## Testing
- `pnpm tsc`
- `pnpm lint`