### PR TITLE
添加 GitHub Release 发布工作流

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: true
+
+      - name: Validate tag version
+        run: |
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "v${PACKAGE_VERSION}" != "${GITHUB_REF_NAME}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match package version ${PACKAGE_VERSION}"
+            exit 1
+          fi
+
+      - name: Run type check
+        run: pnpm tsc
+
+      - name: Run biome
+        run: pnpm lint
+
+      - name: Build extension
+        run: pnpm build
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Package extension
+        id: package
+        run: |
+          mkdir -p releases
+          ASSET_NAME="sgreen-${GITHUB_REF_NAME}.zip"
+          (cd dist && zip -r "../releases/${ASSET_NAME}" .)
+          echo "asset_path=releases/${ASSET_NAME}" >> "$GITHUB_OUTPUT"
+          echo "asset_name=${ASSET_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.asset_name }}
+          path: ${{ steps.package.outputs.asset_path }}
+
+      - name: Create GitHub release
+        run: gh release create "${GITHUB_REF_NAME}" "${{ steps.package.outputs.asset_path }}" --title "${GITHUB_REF_NAME}" --notes "Release ${GITHUB_REF_NAME}" --verify-tag
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,11 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: true
-
       - name: Validate tag version
         run: |
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
@@ -27,6 +22,11 @@ jobs:
             echo "Tag ${GITHUB_REF_NAME} does not match package version ${PACKAGE_VERSION}"
             exit 1
           fi
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: true
 
       - name: Run type check
         run: pnpm tsc

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/node_modules
 .DS_Store
 storybook-static
+releases/
 .env*
 !.env.example
 # Sentry Auth Token


### PR DESCRIPTION
## Summary
- 新增 `release` workflow，在推送 `v*` tag 时自动执行发布流程
- 发布前校验 tag 与 `package.json` 版本一致，避免版本漂移
- 打包 `dist` 为 zip，并上传为 artifact，同时创建 GitHub Release
- 将本地 `releases/` 目录加入 `.gitignore`

## Testing
- 代码检查：`pnpm tsc`、`pnpm lint`、`pnpm build` 通过
- 已确认 workflow YAML 结构和发布步骤符合当前项目发布流程