### PR TITLE
Fix Sentry initialization in background service worker

### DIFF
--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -14,10 +14,14 @@ import { useStore } from '../store'
 let captureException: (err: unknown) => void = () => {}
 
 if (import.meta.env.MODE === 'production') {
-  captureException = Sentry.captureException
-  Sentry.init({
-    dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-  })
+  try {
+    Sentry.init({
+      dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
+    })
+    captureException = Sentry.captureException
+  } catch (err) {
+    console.error('Sentry initialization failed:', err)
+  }
 }
 
 let isRecording = false

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser'
 import { offscreenUrl } from '~/constants'
 import {
   getCurrentTab,
@@ -13,16 +14,10 @@ import { useStore } from '../store'
 let captureException: (err: unknown) => void = () => {}
 
 if (import.meta.env.MODE === 'production') {
-  void import('@sentry/browser')
-    .then((Sentry) => {
-      captureException = Sentry.captureException
-      Sentry.init({
-        dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
-      })
-    })
-    .catch((error) => {
-      console.error('Failed to initialize Sentry in background.', error)
-    })
+  captureException = Sentry.captureException
+  Sentry.init({
+    dsn: 'https://d12dd277a192c6ca69ba59ebb958e6e2@o82598.ingest.sentry.io/4505787043479552',
+  })
 }
 
 let isRecording = false


### PR DESCRIPTION
## Summary
- Replace the background service worker’s runtime `import()` of `@sentry/browser` with a static import
- Keep Sentry initialization production-only while avoiding the MV3 service worker restriction on dynamic imports

## Testing
- `pnpm tsc` passed
- `pnpm lint` passed
- `pnpm build` passed