### PR TITLE
fix: add delayed exit animation for individual keystroke keys

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const tabCaptureModes = ['tab', 'area']
 export const defaultRecordingMode = 'tab'
 
 export const keyboardCodes: { [key: string]: string } = {
+  Escape: 'Esc',
   Backquote: '`',
   Digit1: '1',
   Digit2: '2',

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -13,10 +13,12 @@ export default function StrokeKeysDisplay() {
   }))
 
   const [strokeKeys, setStrokeKeys] = useState<string[]>([])
-  const pendingRemoval = useRef<Set<string>>(new Set())
+  const heldKeys = useRef<Set<string>>(new Set())
+  const clearTimer = useRef<ReturnType<typeof setTimeout>>()
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    pendingRemoval.current.delete(e.code)
+    clearTimeout(clearTimer.current)
+    heldKeys.current.add(e.code)
     setStrokeKeys((prevKeys) => {
       if (prevKeys.includes(e.code)) {
         return prevKeys
@@ -27,18 +29,17 @@ export default function StrokeKeysDisplay() {
   }, [])
 
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
-    const code = e.code
-    pendingRemoval.current.add(code)
-    setTimeout(() => {
-      if (pendingRemoval.current.has(code)) {
-        pendingRemoval.current.delete(code)
-        setStrokeKeys((prevKeys) => prevKeys.filter((key) => key !== code))
-      }
-    }, 500)
+    heldKeys.current.delete(e.code)
+    if (heldKeys.current.size === 0) {
+      clearTimer.current = setTimeout(() => {
+        setStrokeKeys([])
+      }, 500)
+    }
   }, [])
 
   function handleFocus() {
-    pendingRemoval.current.clear()
+    clearTimeout(clearTimer.current)
+    heldKeys.current.clear()
     setStrokeKeys([])
   }
 
@@ -47,6 +48,7 @@ export default function StrokeKeysDisplay() {
     window.addEventListener('keyup', handleKeyUp)
     window.addEventListener('focus', handleFocus)
     return () => {
+      clearTimeout(clearTimer.current)
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
       window.removeEventListener('focus', handleFocus)

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -5,7 +5,7 @@ import { useStore } from '~/entries/store'
 import { isMac, isWindows } from '~/lib/utils'
 
 const metaKey = isMac() ? '⌘' : isWindows() ? '⊞' : 'Meta'
-const MAX_VISIBLE = 5
+const MAX_VISIBLE = 8
 
 export default function StrokeKeysDisplay() {
   const { recordingMode, area } = useStore((state) => ({

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -18,6 +18,10 @@ export default function StrokeKeysDisplay() {
   const clearTimer = useRef<ReturnType<typeof setTimeout>>()
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.repeat) {
+      return
+    }
+
     clearTimeout(clearTimer.current)
     heldKeys.current.add(e.code)
     setStrokeKeys((prevKeys) => {

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -21,9 +21,6 @@ export default function StrokeKeysDisplay() {
     clearTimeout(clearTimer.current)
     heldKeys.current.add(e.code)
     setStrokeKeys((prevKeys) => {
-      if (prevKeys.includes(e.code)) {
-        return prevKeys
-      }
       const next = [...prevKeys, e.code]
       if (next.length > MAX_VISIBLE) {
         return next.slice(next.length - MAX_VISIBLE)

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -5,6 +5,7 @@ import { useStore } from '~/entries/store'
 import { isMac, isWindows } from '~/lib/utils'
 
 const metaKey = isMac() ? '⌘' : isWindows() ? '⊞' : 'Meta'
+const MAX_VISIBLE = 5
 
 export default function StrokeKeysDisplay() {
   const { recordingMode, area } = useStore((state) => ({
@@ -22,9 +23,12 @@ export default function StrokeKeysDisplay() {
     setStrokeKeys((prevKeys) => {
       if (prevKeys.includes(e.code)) {
         return prevKeys
-      } else {
-        return [...prevKeys, e.code]
       }
+      const next = [...prevKeys, e.code]
+      if (next.length > MAX_VISIBLE) {
+        return next.slice(next.length - MAX_VISIBLE)
+      }
+      return next
     })
   }, [])
 

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -1,12 +1,13 @@
 import clsx from 'clsx'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { keyboardCodes } from '~/constants'
 import { useStore } from '~/entries/store'
 import { isMac, isWindows } from '~/lib/utils'
 
 const metaKey = isMac() ? '⌘' : isWindows() ? '⊞' : 'Meta'
 const MAX_VISIBLE = 8
+type StrokeKey = { id: number; code: string }
 
 export default function StrokeKeysDisplay() {
   const { recordingMode, area } = useStore((state) => ({
@@ -14,14 +15,18 @@ export default function StrokeKeysDisplay() {
     area: state.area,
   }))
 
-  const [strokeKeys, setStrokeKeys] = useState<string[]>([])
+  const [strokeKeys, setStrokeKeys] = useState<StrokeKey[]>([])
+  const nextStrokeKeyId = useRef(0)
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     setStrokeKeys((prevKeys) => {
-      if (prevKeys.includes(e.code)) {
+      if (prevKeys.some((key) => key.code === e.code)) {
         return prevKeys
       }
-      const next = [...prevKeys, e.code]
+      const next = [
+        ...prevKeys,
+        { id: nextStrokeKeyId.current++, code: e.code },
+      ]
       if (next.length > MAX_VISIBLE) {
         return next.slice(next.length - MAX_VISIBLE)
       }
@@ -30,7 +35,7 @@ export default function StrokeKeysDisplay() {
   }, [])
 
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
-    setStrokeKeys((prevKeys) => prevKeys.filter((key) => key !== e.code))
+    setStrokeKeys((prevKeys) => prevKeys.filter((key) => key.code !== e.code))
   }, [])
 
   function handleFocus() {
@@ -66,20 +71,20 @@ export default function StrokeKeysDisplay() {
     >
       <div className="flex items-center space-x-2">
         <AnimatePresence>
-          {strokeKeys.map((strokeKey) => (
+          {strokeKeys.map(({ id, code }) => (
             <motion.kbd
-              key={strokeKey}
+              key={id}
               className={clsx(
                 'select-none rounded-lg border bg-background/30 px-4 py-2 text-3xl font-semibold text-foreground shadow-[0_2px_0px_1px_hsl(214.3_31.8%_91.4%)] backdrop-blur',
-                { 'h-[54px] w-48': strokeKey === 'Space' },
+                { 'h-[54px] w-48': code === 'Space' },
               )}
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, transition: { delay: 0.5 } }}
             >
-              {strokeKey.startsWith('Meta')
+              {code.startsWith('Meta')
                 ? metaKey
-                : (keyboardCodes[strokeKey] ?? strokeKey)}
+                : (keyboardCodes[code] ?? code)}
             </motion.kbd>
           ))}
         </AnimatePresence>

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -7,6 +7,7 @@ import { isMac, isWindows } from '~/lib/utils'
 
 const metaKey = isMac() ? '⌘' : isWindows() ? '⊞' : 'Meta'
 const MAX_VISIBLE = 8
+const KEY_EXIT_DELAY_SECONDS = 0.5
 type StrokeKey = { id: number; code: string }
 
 export default function StrokeKeysDisplay() {
@@ -80,7 +81,10 @@ export default function StrokeKeysDisplay() {
               )}
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0 }}
+              exit={{
+                opacity: 0,
+                transition: { delay: KEY_EXIT_DELAY_SECONDS },
+              }}
             >
               {code.startsWith('Meta')
                 ? metaKey

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -7,7 +7,6 @@ import { isMac, isWindows } from '~/lib/utils'
 
 const metaKey = isMac() ? '⌘' : isWindows() ? '⊞' : 'Meta'
 const MAX_VISIBLE = 8
-const KEY_EXIT_DELAY_SECONDS = 0.5
 type StrokeKey = { id: number; code: string }
 
 export default function StrokeKeysDisplay() {
@@ -81,10 +80,7 @@ export default function StrokeKeysDisplay() {
               )}
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
-              exit={{
-                opacity: 0,
-                transition: { delay: KEY_EXIT_DELAY_SECONDS },
-              }}
+              exit={{ opacity: 0 }}
             >
               {code.startsWith('Meta')
                 ? metaKey

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { useCallback, useEffect, useState } from 'react'
 import { keyboardCodes } from '~/constants'
 import { useStore } from '~/entries/store'
 import { isMac, isWindows } from '~/lib/utils'
@@ -14,12 +15,8 @@ export default function StrokeKeysDisplay() {
   }))
 
   const [strokeKeys, setStrokeKeys] = useState<string[]>([])
-  const heldKeys = useRef<Set<string>>(new Set())
-  const clearTimer = useRef<ReturnType<typeof setTimeout>>()
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    clearTimeout(clearTimer.current)
-    heldKeys.current.add(e.code)
     setStrokeKeys((prevKeys) => {
       if (prevKeys.includes(e.code)) {
         return prevKeys
@@ -33,17 +30,10 @@ export default function StrokeKeysDisplay() {
   }, [])
 
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
-    heldKeys.current.delete(e.code)
-    if (heldKeys.current.size === 0) {
-      clearTimer.current = setTimeout(() => {
-        setStrokeKeys([])
-      }, 500)
-    }
+    setStrokeKeys((prevKeys) => prevKeys.filter((key) => key !== e.code))
   }, [])
 
   function handleFocus() {
-    clearTimeout(clearTimer.current)
-    heldKeys.current.clear()
     setStrokeKeys([])
   }
 
@@ -52,7 +42,6 @@ export default function StrokeKeysDisplay() {
     window.addEventListener('keyup', handleKeyUp)
     window.addEventListener('focus', handleFocus)
     return () => {
-      clearTimeout(clearTimer.current)
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
       window.removeEventListener('focus', handleFocus)
@@ -75,23 +64,26 @@ export default function StrokeKeysDisplay() {
         left: recordingMode === 'area' ? area.x + area.width / 2 : undefined,
       }}
     >
-      {strokeKeys.length > 0 && (
-        <div className="flex items-center space-x-2">
-          {strokeKeys.map((strokeKey, idx) => (
-            <kbd
-              key={`${strokeKey}-${idx}`}
+      <div className="flex items-center space-x-2">
+        <AnimatePresence>
+          {strokeKeys.map((strokeKey) => (
+            <motion.kbd
+              key={strokeKey}
               className={clsx(
                 'select-none rounded-lg border bg-background/30 px-4 py-2 text-3xl font-semibold text-foreground shadow-[0_2px_0px_1px_hsl(214.3_31.8%_91.4%)] backdrop-blur',
                 { 'h-[54px] w-48': strokeKey === 'Space' },
               )}
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, transition: { delay: 0.5 } }}
             >
               {strokeKey.startsWith('Meta')
                 ? metaKey
                 : (keyboardCodes[strokeKey] ?? strokeKey)}
-            </kbd>
+            </motion.kbd>
           ))}
-        </div>
-      )}
+        </AnimatePresence>
+      </div>
     </div>
   )
 }

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
-import { AnimatePresence, motion } from 'framer-motion'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { keyboardCodes } from '~/constants'
 import { useStore } from '~/entries/store'
 import { isMac, isWindows } from '~/lib/utils'
@@ -14,8 +13,10 @@ export default function StrokeKeysDisplay() {
   }))
 
   const [strokeKeys, setStrokeKeys] = useState<string[]>([])
+  const pendingRemoval = useRef<Set<string>>(new Set())
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    pendingRemoval.current.delete(e.code)
     setStrokeKeys((prevKeys) => {
       if (prevKeys.includes(e.code)) {
         return prevKeys
@@ -26,10 +27,18 @@ export default function StrokeKeysDisplay() {
   }, [])
 
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
-    setStrokeKeys((prevKeys) => prevKeys.filter((key) => key !== e.code))
+    const code = e.code
+    pendingRemoval.current.add(code)
+    setTimeout(() => {
+      if (pendingRemoval.current.has(code)) {
+        pendingRemoval.current.delete(code)
+        setStrokeKeys((prevKeys) => prevKeys.filter((key) => key !== code))
+      }
+    }, 500)
   }, [])
 
   function handleFocus() {
+    pendingRemoval.current.clear()
     setStrokeKeys([])
   }
 
@@ -60,26 +69,23 @@ export default function StrokeKeysDisplay() {
         left: recordingMode === 'area' ? area.x + area.width / 2 : undefined,
       }}
     >
-      <div className="flex items-center space-x-2">
-        <AnimatePresence>
-          {strokeKeys.map((strokeKey) => (
-            <motion.kbd
-              key={strokeKey}
+      {strokeKeys.length > 0 && (
+        <div className="flex items-center space-x-2">
+          {strokeKeys.map((strokeKey, idx) => (
+            <kbd
+              key={`${strokeKey}-${idx}`}
               className={clsx(
                 'select-none rounded-lg border bg-background/30 px-4 py-2 text-3xl font-semibold text-foreground shadow-[0_2px_0px_1px_hsl(214.3_31.8%_91.4%)] backdrop-blur',
                 { 'h-[54px] w-48': strokeKey === 'Space' },
               )}
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, transition: { delay: 0.5 } }}
             >
               {strokeKey.startsWith('Meta')
                 ? metaKey
                 : (keyboardCodes[strokeKey] ?? strokeKey)}
-            </motion.kbd>
+            </kbd>
           ))}
-        </AnimatePresence>
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { keyboardCodes } from '~/constants'
 import { useStore } from '~/entries/store'
@@ -7,8 +6,6 @@ import { isMac, isWindows } from '~/lib/utils'
 
 const metaKey = isMac() ? '⌘' : isWindows() ? '⊞' : 'Meta'
 const MAX_VISIBLE = 8
-const KEY_EXIT_DELAY_SECONDS = 0.5
-type StrokeKey = { id: number; code: string }
 
 export default function StrokeKeysDisplay() {
   const { recordingMode, area } = useStore((state) => ({
@@ -16,18 +13,18 @@ export default function StrokeKeysDisplay() {
     area: state.area,
   }))
 
-  const [strokeKeys, setStrokeKeys] = useState<StrokeKey[]>([])
-  const nextStrokeKeyId = useRef(0)
+  const [strokeKeys, setStrokeKeys] = useState<string[]>([])
+  const heldKeys = useRef<Set<string>>(new Set())
+  const clearTimer = useRef<ReturnType<typeof setTimeout>>()
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    clearTimeout(clearTimer.current)
+    heldKeys.current.add(e.code)
     setStrokeKeys((prevKeys) => {
-      if (prevKeys.some((key) => key.code === e.code)) {
+      if (prevKeys.includes(e.code)) {
         return prevKeys
       }
-      const next = [
-        ...prevKeys,
-        { id: nextStrokeKeyId.current++, code: e.code },
-      ]
+      const next = [...prevKeys, e.code]
       if (next.length > MAX_VISIBLE) {
         return next.slice(next.length - MAX_VISIBLE)
       }
@@ -36,10 +33,17 @@ export default function StrokeKeysDisplay() {
   }, [])
 
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
-    setStrokeKeys((prevKeys) => prevKeys.filter((key) => key.code !== e.code))
+    heldKeys.current.delete(e.code)
+    if (heldKeys.current.size === 0) {
+      clearTimer.current = setTimeout(() => {
+        setStrokeKeys([])
+      }, 500)
+    }
   }, [])
 
   function handleFocus() {
+    clearTimeout(clearTimer.current)
+    heldKeys.current.clear()
     setStrokeKeys([])
   }
 
@@ -48,6 +52,7 @@ export default function StrokeKeysDisplay() {
     window.addEventListener('keyup', handleKeyUp)
     window.addEventListener('focus', handleFocus)
     return () => {
+      clearTimeout(clearTimer.current)
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
       window.removeEventListener('focus', handleFocus)
@@ -70,29 +75,23 @@ export default function StrokeKeysDisplay() {
         left: recordingMode === 'area' ? area.x + area.width / 2 : undefined,
       }}
     >
-      <div className="flex items-center space-x-2">
-        <AnimatePresence>
-          {strokeKeys.map(({ id, code }) => (
-            <motion.kbd
-              key={id}
+      {strokeKeys.length > 0 && (
+        <div className="flex items-center space-x-2">
+          {strokeKeys.map((strokeKey, idx) => (
+            <kbd
+              key={`${strokeKey}-${idx}`}
               className={clsx(
                 'select-none rounded-lg border bg-background/30 px-4 py-2 text-3xl font-semibold text-foreground shadow-[0_2px_0px_1px_hsl(214.3_31.8%_91.4%)] backdrop-blur',
-                { 'h-[54px] w-48': code === 'Space' },
+                { 'h-[54px] w-48': strokeKey === 'Space' },
               )}
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{
-                opacity: 0,
-                transition: { delay: KEY_EXIT_DELAY_SECONDS },
-              }}
             >
-              {code.startsWith('Meta')
+              {strokeKey.startsWith('Meta')
                 ? metaKey
-                : (keyboardCodes[code] ?? code)}
-            </motion.kbd>
+                : (keyboardCodes[strokeKey] ?? strokeKey)}
+            </kbd>
           ))}
-        </AnimatePresence>
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -7,6 +7,7 @@ import { isMac, isWindows } from '~/lib/utils'
 
 const metaKey = isMac() ? '⌘' : isWindows() ? '⊞' : 'Meta'
 const MAX_VISIBLE = 8
+const KEY_EXIT_DELAY_SECONDS = 0.5
 type StrokeKey = { id: number; code: string }
 
 export default function StrokeKeysDisplay() {
@@ -80,7 +81,10 @@ export default function StrokeKeysDisplay() {
               )}
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, transition: { delay: 0.5 } }}
+              exit={{
+                opacity: 0,
+                transition: { delay: KEY_EXIT_DELAY_SECONDS },
+              }}
             >
               {code.startsWith('Meta')
                 ? metaKey

--- a/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
+++ b/src/entries/contentScript/primary/components/StrokeKeysDisplay.tsx
@@ -60,30 +60,26 @@ export default function StrokeKeysDisplay() {
         left: recordingMode === 'area' ? area.x + area.width / 2 : undefined,
       }}
     >
-      <AnimatePresence>
-        {strokeKeys.length > 0 && (
-          <motion.div
-            className="flex items-center space-x-2"
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0, transition: { delay: 0.3 } }}
-          >
-            {strokeKeys.map((strokeKey, idx) => (
-              <motion.kbd
-                key={`${strokeKey}-${idx}`}
-                className={clsx(
-                  'select-none rounded-lg border bg-background/30 px-4 py-2 text-3xl font-semibold text-foreground shadow-[0_2px_0px_1px_hsl(214.3_31.8%_91.4%)] backdrop-blur',
-                  { 'h-[54px] w-48': strokeKey === 'Space' },
-                )}
-                animate={{ opacity: 1 }}
-              >
-                {strokeKey.startsWith('Meta')
-                  ? metaKey
-                  : (keyboardCodes[strokeKey] ?? strokeKey)}
-              </motion.kbd>
-            ))}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <div className="flex items-center space-x-2">
+        <AnimatePresence>
+          {strokeKeys.map((strokeKey) => (
+            <motion.kbd
+              key={strokeKey}
+              className={clsx(
+                'select-none rounded-lg border bg-background/30 px-4 py-2 text-3xl font-semibold text-foreground shadow-[0_2px_0px_1px_hsl(214.3_31.8%_91.4%)] backdrop-blur',
+                { 'h-[54px] w-48': strokeKey === 'Space' },
+              )}
+              initial={{ opacity: 0, scale: 0.8 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, transition: { delay: 0.5 } }}
+            >
+              {strokeKey.startsWith('Meta')
+                ? metaKey
+                : (keyboardCodes[strokeKey] ?? strokeKey)}
+            </motion.kbd>
+          ))}
+        </AnimatePresence>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Individual keystroke keys now fade out with a 0.5s delay via framer-motion `AnimatePresence` instead of vanishing instantly when released
- Added `Escape` key to `keyboardCodes` mapping (was missing, caused Esc key to not display properly)

## Test plan
- [ ] Press Control+F → both keys appear
- [ ] Release F while holding Control → F fades out after 0.5s delay, Control stays visible
- [ ] Release Control → Control fades out after 0.5s delay
- [ ] Press Escape → "Esc" is displayed and fades out on release
- [ ] Rapidly press/release keys → no visual glitches or duplicate keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)