### PR TITLE
让关闭录制 tab 时继续生成结果而不是直接丢弃

### DIFF
--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -31,7 +31,7 @@ let recordingTabId: number | null = null
 let resultTabId: number | null = null
 const enabledTabs = new Set<number>()
 const stopRecordingFallbackAlarmName = 'stop-recording-fallback'
-const stopRecordingFallbackDelayMs = 5 * 60 * 1000
+const stopRecordingFallbackDelayMs = 60 * 1000
 
 const SCRIPT_ACCESS_ERROR_MESSAGES = [
   'Cannot access a chrome-extension:// URL of different extension',
@@ -46,6 +46,16 @@ function isScriptAccessError(err: unknown) {
       err.message?.includes(message),
     )
   )
+}
+
+function captureUnexpectedTabMessageError(err: unknown) {
+  if (
+    err instanceof Error &&
+    (isScriptAccessError(err) || err.message?.includes('No tab with id'))
+  ) {
+    return
+  }
+  captureException(err)
 }
 
 async function updateActionState(tabId: number, url?: string) {
@@ -89,7 +99,7 @@ function resetRecordingState() {
   void chrome.alarms.clear(stopRecordingFallbackAlarmName)
   if (recordingTabId) {
     sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(
-      captureException,
+      captureUnexpectedTabMessageError,
     )
   }
   chrome.action.setBadgeText({ text: '' })
@@ -112,12 +122,12 @@ function stopRecording() {
   })
   recordingTabId &&
     sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(
-      captureException,
+      captureUnexpectedTabMessageError,
     )
   if (recordingMode === 'desktop') {
     resultTabId &&
       sendTabMessage(resultTabId, { type: 'stop-recording' }).catch(
-        captureException,
+        captureUnexpectedTabMessageError,
       )
   }
 }

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -29,9 +29,9 @@ let isRecording = false
 let recordingMode: RecordingMode | null
 let recordingTabId: number | null = null
 let resultTabId: number | null = null
-let stopRecordingFallbackTimer: ReturnType<typeof setTimeout> | null = null
 const enabledTabs = new Set<number>()
-const stopRecordingFallbackDelay = 3000
+const stopRecordingFallbackAlarmName = 'stop-recording-fallback'
+const stopRecordingFallbackDelay = 5 * 60 * 1000
 
 const SCRIPT_ACCESS_ERROR_MESSAGES = [
   'Cannot access a chrome-extension:// URL of different extension',
@@ -86,12 +86,11 @@ async function executeContentScript(tabId: number) {
 }
 
 function resetRecordingState() {
-  if (stopRecordingFallbackTimer) {
-    clearTimeout(stopRecordingFallbackTimer)
-    stopRecordingFallbackTimer = null
-  }
+  void chrome.alarms.clear(stopRecordingFallbackAlarmName)
   if (recordingTabId) {
-    sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(() => {})
+    void sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(
+      captureException,
+    )
   }
   chrome.action.setBadgeText({ text: '' })
   useStore.setState({ isRecording: false })
@@ -112,23 +111,30 @@ function stopRecording() {
     target: 'offscreen',
   })
   recordingTabId &&
-    sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(() => {})
+    void sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(
+      captureException,
+    )
   if (recordingMode === 'desktop') {
     resultTabId &&
-      sendTabMessage(resultTabId, { type: 'stop-recording' }).catch(() => {})
+      void sendTabMessage(resultTabId, { type: 'stop-recording' }).catch(
+        captureException,
+      )
   }
 }
 
 function stopRecordingWithFallback() {
   stopRecording()
 
-  if (stopRecordingFallbackTimer) {
-    clearTimeout(stopRecordingFallbackTimer)
-  }
-  stopRecordingFallbackTimer = setTimeout(() => {
-    resetRecordingState()
-  }, stopRecordingFallbackDelay)
+  void chrome.alarms.create(stopRecordingFallbackAlarmName, {
+    when: Date.now() + stopRecordingFallbackDelay,
+  })
 }
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === stopRecordingFallbackAlarmName && isRecording) {
+    resetRecordingState()
+  }
+})
 
 chrome.tabs.onActivated.addListener(({ tabId }) => {
   chrome.tabs
@@ -238,10 +244,7 @@ chrome.runtime.onMessage.addListener(
     }
     switch (message.type) {
       case 'recording-complete':
-        if (stopRecordingFallbackTimer) {
-          clearTimeout(stopRecordingFallbackTimer)
-          stopRecordingFallbackTimer = null
-        }
+        void chrome.alarms.clear(stopRecordingFallbackAlarmName)
         if (recordingMode === 'desktop') {
           if (resultTabId) {
             await chrome.tabs.update(resultTabId, { active: true })

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -29,7 +29,9 @@ let isRecording = false
 let recordingMode: RecordingMode | null
 let recordingTabId: number | null = null
 let resultTabId: number | null = null
+let stopRecordingFallbackTimer: ReturnType<typeof setTimeout> | null = null
 const enabledTabs = new Set<number>()
+const stopRecordingFallbackDelay = 3000
 
 const SCRIPT_ACCESS_ERROR_MESSAGES = [
   'Cannot access a chrome-extension:// URL of different extension',
@@ -84,8 +86,12 @@ async function executeContentScript(tabId: number) {
 }
 
 function resetRecordingState() {
+  if (stopRecordingFallbackTimer) {
+    clearTimeout(stopRecordingFallbackTimer)
+    stopRecordingFallbackTimer = null
+  }
   if (recordingTabId) {
-    sendTabMessage(recordingTabId, { type: 'stop-recording' })
+    sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(() => {})
   }
   chrome.action.setBadgeText({ text: '' })
   useStore.setState({ isRecording: false })
@@ -105,10 +111,23 @@ function stopRecording() {
     type: 'stop-recording',
     target: 'offscreen',
   })
-  recordingTabId && sendTabMessage(recordingTabId, { type: 'stop-recording' })
+  recordingTabId &&
+    sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(() => {})
   if (recordingMode === 'desktop') {
-    resultTabId && sendTabMessage(resultTabId, { type: 'stop-recording' })
+    resultTabId &&
+      sendTabMessage(resultTabId, { type: 'stop-recording' }).catch(() => {})
   }
+}
+
+function stopRecordingWithFallback() {
+  stopRecording()
+
+  if (stopRecordingFallbackTimer) {
+    clearTimeout(stopRecordingFallbackTimer)
+  }
+  stopRecordingFallbackTimer = setTimeout(() => {
+    resetRecordingState()
+  }, stopRecordingFallbackDelay)
 }
 
 chrome.tabs.onActivated.addListener(({ tabId }) => {
@@ -145,7 +164,8 @@ chrome.tabs.onRemoved.addListener((tabId) => {
     }
   }
   if (tabId === recordingTabId && isRecording) {
-    resetRecordingState()
+    recordingTabId = null
+    stopRecordingWithFallback()
   }
 })
 
@@ -153,7 +173,7 @@ chrome.action.onClicked.addListener(async (tab) => {
   if (!tab.id) return
 
   if (isRecording) {
-    stopRecording()
+    stopRecordingWithFallback()
   } else {
     if (!isScriptableUrl(tab.url)) {
       enabledTabs.delete(tab.id)
@@ -218,6 +238,10 @@ chrome.runtime.onMessage.addListener(
     }
     switch (message.type) {
       case 'recording-complete':
+        if (stopRecordingFallbackTimer) {
+          clearTimeout(stopRecordingFallbackTimer)
+          stopRecordingFallbackTimer = null
+        }
         if (recordingMode === 'desktop') {
           if (resultTabId) {
             await chrome.tabs.update(resultTabId, { active: true })

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -31,7 +31,7 @@ let recordingTabId: number | null = null
 let resultTabId: number | null = null
 const enabledTabs = new Set<number>()
 const stopRecordingFallbackAlarmName = 'stop-recording-fallback'
-const stopRecordingFallbackDelayMs = 60 * 1000
+const stopRecordingFallbackDelayMs = 60000
 
 const SCRIPT_ACCESS_ERROR_MESSAGES = [
   'Cannot access a chrome-extension:// URL of different extension',
@@ -51,7 +51,7 @@ function isScriptAccessError(err: unknown) {
 function captureUnexpectedTabMessageError(err: unknown) {
   if (
     err instanceof Error &&
-    (isScriptAccessError(err) || err.message?.includes('No tab with id'))
+    (isScriptAccessError(err) || err.message.includes('No tab with id'))
   ) {
     return
   }

--- a/src/entries/background/main.ts
+++ b/src/entries/background/main.ts
@@ -31,7 +31,7 @@ let recordingTabId: number | null = null
 let resultTabId: number | null = null
 const enabledTabs = new Set<number>()
 const stopRecordingFallbackAlarmName = 'stop-recording-fallback'
-const stopRecordingFallbackDelay = 5 * 60 * 1000
+const stopRecordingFallbackDelayMs = 5 * 60 * 1000
 
 const SCRIPT_ACCESS_ERROR_MESSAGES = [
   'Cannot access a chrome-extension:// URL of different extension',
@@ -88,7 +88,7 @@ async function executeContentScript(tabId: number) {
 function resetRecordingState() {
   void chrome.alarms.clear(stopRecordingFallbackAlarmName)
   if (recordingTabId) {
-    void sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(
+    sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(
       captureException,
     )
   }
@@ -111,12 +111,12 @@ function stopRecording() {
     target: 'offscreen',
   })
   recordingTabId &&
-    void sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(
+    sendTabMessage(recordingTabId, { type: 'stop-recording' }).catch(
       captureException,
     )
   if (recordingMode === 'desktop') {
     resultTabId &&
-      void sendTabMessage(resultTabId, { type: 'stop-recording' }).catch(
+      sendTabMessage(resultTabId, { type: 'stop-recording' }).catch(
         captureException,
       )
   }
@@ -126,7 +126,7 @@ function stopRecordingWithFallback() {
   stopRecording()
 
   void chrome.alarms.create(stopRecordingFallbackAlarmName, {
-    when: Date.now() + stopRecordingFallbackDelay,
+    when: Date.now() + stopRecordingFallbackDelayMs,
   })
 }
 

--- a/src/entries/contentScript/primary/main.tsx
+++ b/src/entries/contentScript/primary/main.tsx
@@ -21,7 +21,11 @@ if (import.meta.env.MODE === 'production') {
 chrome.runtime.onMessage.addListener((message, _sener, _sendResponse) => {
   switch (message.type) {
     case 'show-controlbar':
-      useStore.setState({ showControlbar: true })
+      useStore.setState({
+        isRecording: false,
+        showCountdown: false,
+        showControlbar: true,
+      })
       break
     case 'stop-recording':
       useStore.setState({ isRecording: false })

--- a/src/entries/store.ts
+++ b/src/entries/store.ts
@@ -26,7 +26,6 @@ const persistKeys = [
   'scrollbarHidden',
   'showKeystrokes',
   'audio',
-  'isRecording',
   'countdown',
   'showMouseClicks',
   'recordingMode',
@@ -59,6 +58,16 @@ export const useStore = create<IState>()(
         Object.fromEntries(
           Object.entries(state).filter(([key]) => persistKeys.includes(key)),
         ),
+      merge: (persistedState, currentState) => {
+        const {
+          isRecording: _isRecording,
+          showControlbar: _showControlbar,
+          showCountdown: _showCountdown,
+          ...persistedPreferences
+        } = (persistedState ?? {}) as Partial<IState>
+
+        return { ...currentState, ...persistedPreferences }
+      },
     },
   ),
 )

--- a/src/lib/recording.ts
+++ b/src/lib/recording.ts
@@ -167,12 +167,17 @@ class Recorder {
     this.recorder.onerror = (event) => {
       console.error('MediaRecorder error:', event)
     }
+    this.media.getTracks().forEach((track) => {
+      track.addEventListener('ended', () => this.stop(), { once: true })
+    })
     this.recorder.start()
     this.startTime = Date.now()
   }
 
   public async stop() {
-    this.recorder?.stop()
+    if (this.recorder && this.recorder.state !== 'inactive') {
+      this.recorder.stop()
+    }
     this.recorder?.stream.getTracks().forEach((t) => t.stop())
     this.media?.getTracks().forEach((t) => t.stop())
     this.drawTimerId && clearTimeout(this.drawTimerId)


### PR DESCRIPTION
## Summary
- 关闭当前录制 tab 时，改为先请求停止录制，再在超时后兜底重置状态，避免直接丢弃本次录制。
- `Recorder` 增加 track `ended` 监听，并把 `stop()` 做成幂等，保证 tab 关闭后能顺利收尾。
- 顺手清理了 controlbar 的持久化状态，避免旧的录制态挡住界面显示。

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm build`